### PR TITLE
Fix/windows editor ci

### DIFF
--- a/tools/pmtech.lua
+++ b/tools/pmtech.lua
@@ -9,7 +9,7 @@ if platform == "win32" then
             "dir"
 		}
 		linkoptions {
-		  "/DEF:\"pmtech_d.def"
+		  "/DEF:\"pmtech_d.def\""
 		}
 	filter "configurations:Release"
 		prebuildcommands
@@ -18,7 +18,6 @@ if platform == "win32" then
             "dir"
 		}
 		linkoptions {
-		  "/DEF:\"pmtech.def"
+		  "/DEF:\"pmtech.def\""
 		}
 end
-	

--- a/tools/pmtech.lua
+++ b/tools/pmtech.lua
@@ -6,7 +6,6 @@ if platform == "win32" then
 		prebuildcommands
 		{
 			"py -3 ../../../tools/pmbuild_ext/libdef.py ../../../core/put/lib/win32/debug/put.lib ../../../core/pen/lib/win32/debug/pen.lib -o pmtech_d.def",
-            "dir"
 		}
 		linkoptions {
 		  "/DEF:\"pmtech_d.def\""
@@ -15,7 +14,6 @@ if platform == "win32" then
 		prebuildcommands
 		{
 			"py -3 ../../../tools/pmbuild_ext/libdef.py ../../../core/put/lib/win32/release/put.lib ../../../core/pen/lib/win32/release/pen.lib -o pmtech.def",
-            "dir"
 		}
 		linkoptions {
 		  "/DEF:\"pmtech.def\""

--- a/tools/pmtech.lua
+++ b/tools/pmtech.lua
@@ -6,6 +6,7 @@ if platform == "win32" then
 		prebuildcommands
 		{
 			"py -3 ../../../tools/pmbuild_ext/libdef.py ../../../core/put/lib/win32/debug/put.lib ../../../core/pen/lib/win32/debug/pen.lib -o pmtech_d.def",
+            "dir"
 		}
 		linkoptions {
 		  "/DEF:\"pmtech_d.def"
@@ -13,7 +14,8 @@ if platform == "win32" then
 	filter "configurations:Release"
 		prebuildcommands
 		{
-			"py -3 ../../../tools/pmbuild_ext/libdef.py ../../../core/put/lib/win32/release/put.lib ../../../core/pen/lib/win32/release/pen.lib -o pmtech.def"
+			"py -3 ../../../tools/pmbuild_ext/libdef.py ../../../core/put/lib/win32/release/put.lib ../../../core/pen/lib/win32/release/pen.lib -o pmtech.def",
+            "dir"
 		}
 		linkoptions {
 		  "/DEF:\"pmtech.def"


### PR DESCRIPTION
Fixes build CI for windows-editor.

Not quite sure how this was previously working fine on CI and on local builds but there was a missing closing `\"` literal quotation around the `/DEF` argument for the linker supplied in premake.

CI is confirmed fixed on this branch.